### PR TITLE
Create packaged emulator compatible with mach.

### DIFF
--- a/scripts/package-emulator.sh
+++ b/scripts/package-emulator.sh
@@ -1,33 +1,45 @@
 #!/bin/bash
-set -
-cd ..
-. setup.sh
+source build/envsetup.sh
+TARGET_ARCH=$(get_build_var TARGET_ARCH)
+lunch "aosp_${TARGET_ARCH}-userdebug"
 PRODUCT_OUT=$(get_build_var PRODUCT_OUT)
-HOST_OUT=$(get_build_var HOST_OUT)
 OUT_DIR=$(get_abs_build_var OUT_DIR)
+OUT_TEMP_DIR=$(get_build_var OUT_DIR)/avd_package
+# Default name compatible with mach's emulator extractor.
+AVD_NAME="test-1"
+AVD_DIR_NAME="${AVD_NAME}.avd"
+
+mkdir -p $OUT_TEMP_DIR/$AVD_DIR_NAME
+
+echo "avd.ini.encoding=UTF-8
+path=/home/cltbld/.android/avd/${AVD_DIR_NAME}
+path.rel=avd/${AVD_DIR_NAME}
+target=android-29" > $OUT_TEMP_DIR/$AVD_NAME.ini
+
+CONFIG_FILE=$OUT_TEMP_DIR/$AVD_DIR_NAME/config.ini
+cp $PRODUCT_OUT/config.ini $CONFIG_FILE
+sed -i 's/image\.sysdir\.1=x86\//image\.sysdir\.1=/g' $CONFIG_FILE
+echo -e "abi.type=$TARGET_ARCH\nhw.cpu.arch=$TARGET_ARCH" >> $CONFIG_FILE
 
 EMULATOR_FILES=(\
-	.config \
-	load-config.sh \
-	run-emulator.sh \
-	${HOST_OUT}/bin/adb \
-	${HOST_OUT}/bin/emulator \
-	${HOST_OUT}/bin/emulator-arm \
-	${HOST_OUT}/bin/mksdcard \
-	${HOST_OUT}/bin/qemu-android-x86 \
-	${HOST_OUT}/lib \
-	${HOST_OUT}/usr \
-	development/tools/emulator/skins \
-	prebuilts/qemu-kernel/arm/kernel-qemu-armv7 \
-	${PRODUCT_OUT}/system/build.prop \
-	${PRODUCT_OUT}/system.img \
-	${PRODUCT_OUT}/userdata.img \
-	${PRODUCT_OUT}/ramdisk.img)
+       ${PRODUCT_OUT}/cache.img \
+       ${OUT_TEMP_DIR}/${AVD_NAME}.ini \
+       ${OUT_TEMP_DIR}/${AVD_DIR_NAME}/config.ini \
+       ${PRODUCT_OUT}/encryptionkey.img \
+       ${PRODUCT_OUT}/kernel-ranchu \
+       ${PRODUCT_OUT}/ramdisk.img \
+       ${PRODUCT_OUT}/VerifiedBootParams.textproto \
+       ${PRODUCT_OUT}/system/build.prop \
+       ${PRODUCT_OUT}/system-qemu.img \
+       ${PRODUCT_OUT}/userdata.img)
 
 EMULATOR_ARCHIVE="${OUT_DIR}/emulator.tar.gz"
 
-echo "Creating emulator archive at $EMULATOR_ARCHIVE"
+echo "Creating emulator archive at ${EMULATOR_ARCHIVE}"
 
-rm -rf $EMULATOR_ARCHIVE
-tar -cvzf $EMULATOR_ARCHIVE --transform 's,^,b2g-distro/,S' --show-transformed-names ${EMULATOR_FILES[@]}
-
+# Create a file structure needed by mach.
+rm -f $EMULATOR_ARCHIVE
+tar -cvzf $EMULATOR_ARCHIVE --transform "\
+s,^${PRODUCT_OUT}/system/,avd/${AVD_DIR_NAME}/,S;\
+s,^${PRODUCT_OUT}/,avd/${AVD_DIR_NAME}/,S;\
+s,^${OUT_TEMP_DIR}/,avd/,S" --show-transformed-names ${EMULATOR_FILES[@]}


### PR DESCRIPTION
Creates/copies all the necessary files and folders need for a packaged
emulator to work with mach's un-packaging script and emulator starting
script.